### PR TITLE
Replace `basestring` and fix #26

### DIFF
--- a/mopidy_json_client/messages.py
+++ b/mopidy_json_client/messages.py
@@ -151,7 +151,7 @@ class ErrorMessage(object):
 
         output['title'] = input_error.get('message')
         inner_data = input_error.get('data')
-        if isinstance(inner_data, basestring):
+        if isinstance(inner_data, str):
             output['error'] = inner_data
         elif 'message' in input_error:
             output['error'] = inner_data.get('message')

--- a/mopidy_json_client/methods_2_0/tracklist.py
+++ b/mopidy_json_client/methods_2_0/tracklist.py
@@ -109,7 +109,7 @@ class TracklistController (MopidyWSController):
         .. deprecated:: 1.0
             The ``tracks`` and ``uri`` arguments. Use ``uris``.
         '''
-        return self.mopidy_request('core.tracklist.add', tracks=tracks, at_position=at_position, uri=uri, uris=uris, **options)
+        return self.mopidy_request('core.tracklist.add', tracks=tracks, at_position=at_position, uris=uris, **options)
 
     def get_eot_tlid(self, **options):
         '''The TLID of the track that will be played after the current track.


### PR DESCRIPTION
- Replaces `basestring` usage with `str` (might drop python 2 support, a better solution would probably be to use `basestring` from future package)
- Fixes #26 

Since Mopidy is already on version 3.0, it would be better if this client is also updated accordingly. However, I needed a few specific functions for my project which seem to be working after performing these small fixes. I have only tested it on docker image `python:3.7.4-buster`